### PR TITLE
LatestArticles fix to mobile layout

### DIFF
--- a/src/components/latestarticles.astro
+++ b/src/components/latestarticles.astro
@@ -99,7 +99,7 @@ const otherPosts = posts.slice(1, 5)
                       post.data.socialImage
                     }
                     alt={post.data.title + ' featured image'}
-                    class="block lg:block rounded-md w-full h-64 md:h-32 m-4 md:m-0 object-cover bg-purple-100 dark:bg-purple-800"
+                    class="block lg:block rounded-md w-full h-64 md:h-32 p-4 md:p-0 object-cover bg-purple-100 dark:bg-purple-800"
                   />
                 </a>
                 <div class="bg-white dark:bg-gray-800 rounded px-4 md:col-span-2">


### PR DESCRIPTION
Hello, thanks for sharing this theme.

I'm trying to fix an issue i run into with LatestArticles component on mobile screens. The featured image of "otherPosts" is out of their container right border.
![2023-03-21](https://user-images.githubusercontent.com/68308554/226722513-e17f8555-25b9-410f-93ca-154edb2ef083.png)