### PR TITLE
Fix map not displayed in 2022-08-23-sample-mdx-post

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -17,7 +17,10 @@ import markdoc from '@astrojs/markdoc'
 // https://astro.build/config
 export default defineConfig({
   vite: {
-    plugins: [tailwindcss()]
+    plugins: [tailwindcss()],
+    optimizeDeps: {
+      include: ['astro-leaflet > leaflet'],
+    }
   },
   site: 'https://hellotham.github.io',
   base: '/hello-astro/',


### PR DESCRIPTION
Map is not displayed on ```npm run dev``` because of leaflet being in CommonJS.

As stated in [vite](https://vite.dev/config/dep-optimization-options.html#optimizedeps-exclude):
> CommonJS dependencies should not be excluded from optimization.
> If an ESM dependency is excluded from optimization, but has a nested
> CommonJS dependency, the CommonJS dependency should be added
> to optimizeDeps.include.

Fix is documented in [astro-leaflet](https://github.com/pascal-brand38/astro-leaflet?tab=readme-ov-file#-troubleshooting)